### PR TITLE
Resolve "bugfix/bbox-conversion"

### DIFF
--- a/notebooks/cuhk_ave_cvt.py
+++ b/notebooks/cuhk_ave_cvt.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import cv2
 import pandas as pd
+import math
 from ssvad_metrics.data_schema import VADAnnotation, VADFrame, AnomalousRegion
 
 
@@ -56,10 +57,10 @@ def main(args):
                 anomalous_regions = [
                     AnomalousRegion(
                         bounding_box=[
-                            int(row["x"]),
-                            int(row["y"]),
-                            int(row["x"] + row["w"]),
-                            int(row["y"] + row["h"])
+                            math.floor(row["x"]-row["w"]/2),
+                            math.floor(row["y"]-row["h"]/2),
+                            math.ceil(row["x"]+row["w"]/2),
+                            math.ceil(row["y"]+row["h"]/2)
                         ],
                         score=1.0
                     )

--- a/notebooks/streetscene_cvt.py
+++ b/notebooks/streetscene_cvt.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import cv2
 import pandas as pd
+import math
 from ssvad_metrics.data_schema import VADAnnotation, VADFrame, AnomalousRegion
 
 
@@ -53,10 +54,10 @@ def main(args):
                 anomalous_regions = [
                     AnomalousRegion(
                         bounding_box=[
-                            int(row["x"]),
-                            int(row["y"]),
-                            int(row["x"] + row["w"]),
-                            int(row["y"] + row["h"])
+                            math.floor(row["x"]-row["w"]/2),
+                            math.floor(row["y"]-row["h"]/2),
+                            math.ceil(row["x"]+row["w"]/2),
+                            math.ceil(row["y"]+row["h"]/2)
                         ],
                         score=1.0
                     )

--- a/notebooks/ucsd_ped_ss_cvt.py
+++ b/notebooks/ucsd_ped_ss_cvt.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import cv2
 import pandas as pd
+import math
 
 
 def main(args):
@@ -57,10 +58,10 @@ def main(args):
                 anomalous_regions = [
                     {
                         "bounding_box": [
-                            int(row["x"]),
-                            int(row["y"]),
-                            int(row["x"] + row["w"]),
-                            int(row["y"] + row["h"])
+                            math.floor(row["x"]-row["w"]/2),
+                            math.floor(row["y"]-row["h"]/2),
+                            math.ceil(row["x"]+row["w"]/2),
+                            math.ceil(row["y"]+row["h"]/2)
                         ],
                         "score": 1.0
                     }


### PR DESCRIPTION
## Description

Fix bounding box conversion bug. 

* Bug: The bounding box groundtruth in the original txt file has the format [xcenter, ycenter, w, h]. In the previous approach there is a bug where this groundtruth is considered as [xmin, ymin, w, h]. So that in the previous approach it produces output bbox like the this: [xcenter, ycenter, xcenter + w, ycenter + h]

* How I solve this bug: By following the readme in the groundtruth folder, they have listed the way to change the bbox format to [top_left_x, top_left_y, bottom_right_x, bottom_right_y] which is in the following way:  [floor(xcenter - w / 2), floor(ycenter - h / 2), ceil(xcenter + w / 2 ), ceil(ycenter + h / 2)]. My implementation in python code:
```python
import math
math.floor(row["x"]-row["w"]/2),
math.floor(row["y"]-row["h"]/2),
math.ceil(row["x"]+row["w"]/2),
math.ceil(row["y"]+row["h"]/2)
```

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings